### PR TITLE
(#11) sleep in a context interruptable way

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ First time it connects it attempts to replicate all messages, as the subscriptio
 
 ## Status
 
-This is a pretty new project and not yet used in production, use with caution and I'd love any feedback you might have
+This is a pretty new project and not yet used in production, use with caution and I'd love any feedback you might have - especially design ideas about multi worker order preserving replication!
+
+Initial packages for el6 and el7 64bit systems are now on the Choria YUM repository, see below.
 
 ## Configuration
 
@@ -193,7 +195,7 @@ In all cases the `name` label is the configured name or generated one as describ
 
 ## Packages
 
-RPMs will be in the Choria yum repository for el6 and 7 64bit systems:
+RPMs are hosted in the Choria yum repository for el6 and 7 64bit systems:
 
 ```ini
 [choria]
@@ -206,3 +208,5 @@ protect=1
 ```
 
 On a RHEL7 system the systemd unit files are using templating, if you have a configuration section for `cmdb` you would run that using `systemctl start stream-replicator@cmdb`.
+
+On a RHEL6 system you can edit `/etc/sysconfig/stream-replicator` and set `TOPICS="cmdb monitor"` to start a instance for the configured topics matching the names.

--- a/limiter/memory/memory.go
+++ b/limiter/memory/memory.go
@@ -1,7 +1,6 @@
 package memory
 
 import (
-	"fmt"
 	"sync"
 	"time"
 
@@ -123,7 +122,6 @@ func (m *Limiter) scrubber() {
 	killtime := time.Now().Add((-1 * m.age) - (10 * time.Minute))
 
 	for i, t := range m.seen {
-		fmt.Printf("(%s) %s: %s < %s\n", time.Now(), i, t, killtime)
 		if t.Before(killtime) {
 			delete(m.seen, i)
 		}


### PR DESCRIPTION
With using a simple time.Sleep() the context interruption only happens
after the sleep is done which is annoying

this now uses a time.Timer and a select block to wait for either the
sleep time to pass or the context to signal exit is required