### PR TITLE
(#5) supports SSL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 vendor
+.DS_Store
 stream-replicator
 sr.yaml
 *.rpm

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -57,7 +57,7 @@ func Run() {
 	go interruptHandler()
 
 	writePID(pidfile)
-	startReplicator(ctx, wg, done, topicconf)
+	startReplicator(ctx, wg, done, topicconf, config.TLS())
 
 	wg.Wait()
 }
@@ -88,8 +88,8 @@ func interruptHandler() {
 	}
 }
 
-func startReplicator(ctx context.Context, wg *sync.WaitGroup, done chan int, topic config.TopicConf) {
-	err := rep.Setup(topic)
+func startReplicator(ctx context.Context, wg *sync.WaitGroup, done chan int, topic config.TopicConf, tls bool) {
+	err := rep.Setup(topic, tls)
 	if err != nil {
 		logrus.Errorf("Could not configure Replicator: %s", err.Error())
 		return

--- a/replicator/replicator.go
+++ b/replicator/replicator.go
@@ -16,13 +16,14 @@ import (
 
 type Copier struct {
 	config config.TopicConf
-
-	Log *logrus.Entry
+	tls    bool
+	Log    *logrus.Entry
 }
 
 // Setup validates the configuration of the copier and sets defaults where possible
-func (c *Copier) Setup(topic config.TopicConf) error {
+func (c *Copier) Setup(topic config.TopicConf, tls bool) error {
 	c.config = topic
+	c.tls = tls
 
 	if c.config.Topic == "" {
 		return fmt.Errorf("A topic is required")
@@ -74,7 +75,7 @@ func (c *Copier) Run(ctx context.Context, wg *sync.WaitGroup) {
 	defer wg.Done()
 
 	for i := 0; i < c.config.Workers; i++ {
-		w := NewWorker(i, c.config, c.Log)
+		w := NewWorker(i, c.config, c.tls, c.Log)
 		wg.Add(1)
 		go w.Run(ctx, wg)
 	}

--- a/ssl/config.go
+++ b/ssl/config.go
@@ -1,0 +1,75 @@
+package ssl
+
+type config struct {
+	ca     string
+	key    string
+	cert   string
+	ssldir string
+	verify bool
+	p      personality
+}
+
+type Option func(*config) error
+
+func Configure(personality string, opts ...Option) error {
+	mu.Lock()
+	defer mu.Unlock()
+
+	cfg := &config{}
+	for _, opt := range opts {
+		if err := opt(cfg); err != nil {
+			return err
+		}
+	}
+
+	switch personality {
+	case "choria":
+		cfg.p = &puppet{cfg}
+	default:
+		cfg.p = &manual{cfg}
+	}
+
+	return nil
+}
+
+func CA(path string) Option {
+	return func(c *config) error {
+		c.ca = path
+		return nil
+	}
+}
+
+func Key(path string) Option {
+	return func(c *config) error {
+		c.key = path
+		return nil
+	}
+}
+
+func Cert(path string) Option {
+	return func(c *config) error {
+		c.cert = path
+		return nil
+	}
+}
+
+func Directory(path string) Option {
+	return func(c *config) error {
+		c.ssldir = path
+		return nil
+	}
+}
+
+func Verify() Option {
+	return func(c *config) error {
+		c.verify = true
+		return nil
+	}
+}
+
+func UnVerified() Option {
+	return func(c *config) error {
+		c.verify = false
+		return nil
+	}
+}

--- a/ssl/manual.go
+++ b/ssl/manual.go
@@ -1,0 +1,25 @@
+package ssl
+
+import (
+	"path/filepath"
+)
+
+type manual struct {
+	c *config
+}
+
+func (m *manual) SSLDir() (string, error) {
+	return m.c.ssldir, nil
+}
+
+func (m *manual) CAPath() (string, error) {
+	return filepath.Join(m.c.ssldir, m.c.ca), nil
+}
+
+func (m *manual) KeyPath() (string, error) {
+	return filepath.Join(m.c.ssldir, m.c.key), nil
+}
+
+func (m *manual) CertPath() (string, error) {
+	return filepath.Join(m.c.ssldir, m.c.cert), nil
+}

--- a/ssl/puppet.go
+++ b/ssl/puppet.go
@@ -1,0 +1,100 @@
+package ssl
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type puppet struct {
+	c *config
+}
+
+func (p *puppet) SSLDir() (string, error) {
+	if p.c.ssldir != "" {
+		return p.c.ssldir, nil
+	}
+
+	if os.Getuid() == 0 {
+		path, err := p.puppetSetting("ssldir")
+		if err != nil {
+			return "", err
+		}
+
+		// store it so future calls to this wil not call out to Puppet again
+		p.c.ssldir = path
+
+		return path, nil
+	}
+
+	if os.Getenv("HOME") == "" {
+		return "", fmt.Errorf("cannot determine home dir, set HOME environment or configure ssldir")
+	}
+
+	return filepath.Join(os.Getenv("HOME"), ".puppetlabs", "etc", "puppet", "ssl"), nil
+}
+
+func (p *puppet) CAPath() (string, error) {
+	ssl, err := p.SSLDir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(ssl, "certs", "ca.pem"), nil
+}
+
+func (p *puppet) KeyPath() (string, error) {
+	ssl, err := p.SSLDir()
+	if err != nil {
+		return "", err
+	}
+
+	cn, err := p.certname()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(ssl, "private_keys", fmt.Sprintf("%s.pem", cn)), nil
+}
+
+func (p *puppet) CertPath() (string, error) {
+	ssl, err := p.SSLDir()
+	if err != nil {
+		return "", err
+	}
+
+	cn, err := p.certname()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(ssl, "certs", fmt.Sprintf("%s.pem", cn)), nil
+}
+
+func (p *puppet) puppetSetting(setting string) (string, error) {
+	args := []string{"apply", "--configprint", setting}
+
+	out, err := exec.Command("puppet", args...).Output()
+	if err != nil {
+		return "", err
+	}
+
+	return strings.Replace(string(out), "\n", "", -1), nil
+}
+
+func (p *puppet) certname() (string, error) {
+	certname, err := os.Hostname()
+	if err != nil {
+		return "", err
+	}
+
+	if os.Getuid() != 0 {
+		if u, ok := os.LookupEnv("USER"); ok {
+			certname = fmt.Sprintf("%s.mcollective", u)
+		}
+	}
+
+	return certname, nil
+}

--- a/ssl/ssl.go
+++ b/ssl/ssl.go
@@ -1,0 +1,180 @@
+package ssl
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"sync"
+)
+
+type personality interface {
+	SSLDir() (string, error)
+	CAPath() (string, error)
+	KeyPath() (string, error)
+	CertPath() (string, error)
+}
+
+var cfg *config
+var mu *sync.Mutex
+
+func init() {
+	mu = &sync.Mutex{}
+}
+
+func SSLContext() (*http.Transport, error) {
+	tlsConfig, err := TLSConfig()
+	if err != nil {
+		return &http.Transport{}, err
+	}
+
+	transport := &http.Transport{TLSClientConfig: tlsConfig}
+
+	return transport, nil
+}
+
+func TLSConfig() (tlsc *tls.Config, err error) {
+	pub, _ := CertPath()
+	pri, _ := KeyPath()
+	ca, _ := CAPath()
+
+	cert, err := tls.LoadX509KeyPair(pub, pri)
+	if err != nil {
+		return nil, fmt.Errorf("Could not load certificate %s and key %s: %s", pub, pri, err)
+	}
+
+	caCert, err := ioutil.ReadFile(ca)
+
+	if err != nil {
+		return
+	}
+
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM(caCert)
+
+	tlsc = &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      caCertPool,
+		MinVersion:   tls.VersionTLS12,
+	}
+
+	if !cfg.verify {
+		tlsc.InsecureSkipVerify = true
+	}
+
+	tlsc.BuildNameToCertificate()
+
+	return
+}
+
+func Check() (errors []string, ok bool) {
+	if _, err := cfg.p.SSLDir(); err != nil {
+		errors = append(errors, fmt.Sprintf("SSL Directory does not exist: %s", err))
+		return errors, false
+	}
+
+	if c, err := cfg.p.CertPath(); err != nil {
+		if _, err := os.Stat(c); err != nil {
+			errors = append(errors, fmt.Sprintf("The Public Certificate %s does not exist", c))
+		}
+
+		if _, err = pemDecode(c); err != nil {
+			errors = append(errors, fmt.Sprintf("The Public Certificate %s does not contain valid PEM data", c))
+		}
+	} else {
+		errors = append(errors, fmt.Sprintf("Could not determine Public Certificate path: %s", err))
+	}
+
+	if c, err := cfg.p.KeyPath(); err == nil {
+		if _, err := os.Stat(c); err != nil {
+			errors = append(errors, fmt.Sprintf("The Private Key %s does not exist", c))
+		}
+
+		if _, err = pemDecode(c); err != nil {
+			errors = append(errors, fmt.Sprintf("The Private Key %s does not contain valid PEM data", c))
+		}
+	} else {
+		errors = append(errors, fmt.Sprintf("Could not determine Private Certificate path: %s", err))
+	}
+
+	if c, err := cfg.p.CAPath(); err == nil {
+		if _, err := os.Stat(c); err != nil {
+			errors = append(errors, fmt.Sprintf("The CA %s does not exist", c))
+		}
+
+		if _, err = pemDecode(c); err != nil {
+			errors = append(errors, fmt.Sprintf("The CA %s does not contain valid PEM data", c))
+		}
+	} else {
+		errors = append(errors, fmt.Sprintf("Could not determine CA path: %s", err.Error()))
+	}
+
+	if len(errors) == 0 {
+		ok = true
+	}
+
+	return errors, ok
+}
+
+func SSLDir() (string, error) {
+	return cfg.p.SSLDir()
+}
+
+func CAPath() (string, error) {
+	return cfg.p.CAPath()
+}
+
+func KeyPath() (string, error) {
+	return cfg.p.KeyPath()
+}
+
+func CertPath() (string, error) {
+	return cfg.p.CertPath()
+}
+
+func CertificatePEM() (*pem.Block, error) {
+	c, _ := CertPath()
+	p, err := pemDecode(c)
+	if err != nil {
+		return nil, fmt.Errorf("Could not load Certificate data: %s", err)
+	}
+
+	return p, nil
+}
+
+func KeyPEM() (*pem.Block, error) {
+	c, _ := KeyPath()
+	p, err := pemDecode(c)
+	if err != nil {
+		return nil, fmt.Errorf("Could not load Key data: %s", err)
+	}
+
+	return p, nil
+}
+
+func CAPEM() (*pem.Block, error) {
+	c, _ := CAPath()
+	p, err := pemDecode(c)
+	if err != nil {
+		return nil, fmt.Errorf("Could not load CA data: %s", err)
+	}
+
+	return p, nil
+}
+
+func pemDecode(path string) (*pem.Block, error) {
+	cdata, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("file not found %s: %s", path, err)
+	}
+
+	pb, _ := pem.Decode(cdata)
+	if pb == nil {
+		return pb, fmt.Errorf("failed to parse pem data in %s", path)
+	}
+
+	return pb, nil
+}


### PR DESCRIPTION
This supports 2 SSL schemes - Puppet and Manual.

Puppet scheme will do what choria does and use puppet AIO paths where
manual lets one pass in paths to all the various files

At present this is undocumented because what I really have to do is a
per source/target TLS config to allow different CA's cross DC boundaries
but the implementation right now would not support that, it's still
useful code so putting it in and will later refactor it to unique setups
perhaps defaulting to a global config when per connection isnt set