### PR TITLE
(#24) use the state_dir as temp dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue |Description                                                                                              |
 |----------|------|---------------------------------------------------------------------------------------------------------|
+|2018/01/01|24    |Write the last-seen cache tempfile in the statedir to support multi partition machines                   |
 |2018/01/01|      |Release 0.0.2                                                                                            |
 |2018/01/01|16    |Save the last-seen data regularly and on shutdown.  Restore state on startup                             |
 |2017/12/31|19    |Record via prometheus the size of messages received and published                                        |

--- a/limiter/memory/memory.go
+++ b/limiter/memory/memory.go
@@ -160,6 +160,12 @@ func (m *Limiter) readCache() error {
 		return err
 	}
 
+	m.mu.Unlock()
+	m.scrub()
+	m.mu.Lock()
+
+	m.log.Infof("Read %d bytes of last-seen data from cache file %s.  After scrubbing old entries the last-seen data has %d entries.", len(d), m.statefile, len(m.seen))
+
 	return nil
 }
 
@@ -171,7 +177,7 @@ func (m *Limiter) writeCache() error {
 		return nil
 	}
 
-	tmpfile, err := ioutil.TempFile("", "example")
+	tmpfile, err := ioutil.TempFile(config.StateDirectory(), "example")
 	if err != nil {
 		return err
 	}
@@ -195,6 +201,8 @@ func (m *Limiter) writeCache() error {
 	if err != nil {
 		return err
 	}
+
+	m.log.Debugf("Wrote %d bytes to last seen cache %s", len(content), m.statefile)
 
 	return nil
 }


### PR DESCRIPTION
On machines with multiple partitions and tmp on a different place than
the state dir the os.Rename() would fail, now we write the temp file in
the same directory as the target so it always works