### PR TITLE
(#58) simplify limiter/advisor interactions

### DIFF
--- a/advisor/stats.go
+++ b/advisor/stats.go
@@ -31,5 +31,4 @@ func init() {
 	prometheus.MustRegister(recoverAdvisoryCtr)
 	prometheus.MustRegister(expiredAdvisoryCtr)
 	prometheus.MustRegister(publishErrCtr)
-
 }


### PR DESCRIPTION
This simplifies the limiter and advisor interaction, these 2 things
have competing models of time and how much grace to give nodes etc
so now instead of the limiter telling the advisor a node is expiring
the advisor is figuring this out for itself