### PR TITLE
(#65) puppet module incorrectly enumerates the advisory.cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue |Description                                                                                              |
 |----------|------|---------------------------------------------------------------------------------------------------------|
+|2018/01/29|65    |Correctly list advisory target modes in the puppet module as `source` and `target`                       |
 |2018/01/29|      |Release 0.0.6                                                                                            |
 |2018/01/29|58    |Ability to send advisories about tracked nodes when they stop sending metadata                           |
 |2018/01/17|51    |Treat sysconfig file as configuration on el6                                                             |

--- a/puppet/types/advisory.pp
+++ b/puppet/types/advisory.pp
@@ -1,5 +1,5 @@
 type Stream_replicator::Advisory = Struct[{
     target => String,
-    cluster => Enum["cluster", "source"],
+    cluster => Enum["source", "target"],
     age => Pattern[/\d+(m|h)/]
 }]


### PR DESCRIPTION
It allows cluster an source but should allow source and target
as valid entries for the advisory target