### PR TITLE
(#82) do not zero the logfile

### DIFF
--- a/packager/templates/el/el6/stream-replicator.init
+++ b/packager/templates/el/el6/stream-replicator.init
@@ -51,7 +51,7 @@ start() {
         pidfile="${piddir}/${c}.pid"
         rm -f ${pidfile}
 
-        daemon --pidfile=${pidfile} " { nohup ${exec} --config ${conffile} --topic ${c} --pid ${pidfile} > ${logfile} 2>&1 & } ; sleep 0.5 ; [ -f ${pidfile} ]"
+        daemon --pidfile=${pidfile} " { nohup ${exec} --config ${conffile} --topic ${c} --pid ${pidfile} >> ${logfile} 2>&1 & } ; sleep 0.5 ; [ -f ${pidfile} ]"
 
         if [ $? = 0 ] && [ -f ${pidfile} ]; then
             echo "${c}"


### PR DESCRIPTION
Startup crash logs on el6 are also written to the normal logfile
and the process that does this zero's the file

This fixes that problem, now multiple stream replicator startup
messages are all seen in the logfile