### PR TITLE
(#85) handle STAN connection errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ When there are many workers or it's specified to belong to a queue group a Durab
 
 First time it connects it attempts to replicate all messages, as the subscription is Durable it will from then on continue where it left off.
 
+## Requirements
+
+For reliable operation where connection issues get correctly detected NATS Streaming Server version 0.10.0 or newer is required
+
 ## Status
 
 This is a pretty new project that is being used in production, however as it is new and developing use with caution. I'd love any feedback you might have - especially design ideas about multi worker order preserving replication!
@@ -370,4 +374,4 @@ A Puppet module to install and manage the Stream Replicator can be found on the 
 
 ## Thanks
 
-<img src="https://packagecloud.io/images/packagecloud-badge.png" width="158">
+<a href="https://packagecloud.io/"><img src="https://packagecloud.io/images/packagecloud-badge.png" width="158"></a>

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -34,6 +34,8 @@ var (
 	enrollIdentity string
 	enrollCA       string
 	enrollDir      string
+
+	reconn chan string
 )
 
 func Run() {
@@ -54,6 +56,8 @@ func Run() {
 	enroll.Flag("dir", "Directory to write SSL configuration to").Required().StringVar(&enrollDir)
 
 	command := kingpin.MustParse(app.Parse(os.Args[1:]))
+
+	reconn = make(chan string, 5)
 
 	ctx, cancel = context.WithCancel(context.Background())
 	defer cancel()
@@ -118,7 +122,7 @@ func runReplicate() {
 		os.Exit(1)
 	}
 
-	go interruptHandler()
+	go interruptHandler(wg)
 
 	writePID(pidfile)
 
@@ -141,15 +145,31 @@ func writePID(pidfile string) {
 	}
 }
 
-func interruptHandler() {
+func interruptHandler(wg *sync.WaitGroup) {
+	defer wg.Done()
+
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 
 	for {
 		select {
+		case reason := <-reconn:
+			logrus.Errorf("Restarting replicator after: %s", reason)
+
+			// stops everything and sleep a bit to give state saves a bit of time etc
+			cancel()
+			time.Sleep(1 * time.Second)
+
+			err := syscall.Exec(os.Args[0], os.Args, os.Environ())
+			if err != nil {
+				logrus.Errorf("Could not restart Stream Replicator: %s", err)
+			}
+
 		case sig := <-sigs:
 			logrus.Infof("Shutting down on %s", sig)
 			cancel()
+			return
+
 		case <-ctx.Done():
 			return
 		}
@@ -157,7 +177,7 @@ func interruptHandler() {
 }
 
 func startReplicator(ctx context.Context, wg *sync.WaitGroup, done chan int, topic *config.TopicConf, topicname string) {
-	err := rep.Setup(topicname, topic)
+	err := rep.Setup(topicname, topic, reconn)
 	if err != nil {
 		logrus.Errorf("Could not configure Replicator: %s", err)
 		return

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -13,13 +13,14 @@ import (
 
 // Connection holds a connection to NATS Streaming
 type Connection struct {
-	url  string
-	log  *logrus.Entry
-	conn stan.Conn
-	name string
-	cfg  *config.TopicConf
-	id   string
-	tls  bool
+	url      string
+	log      *logrus.Entry
+	conn     stan.Conn
+	natsConn *nats.Conn
+	name     string
+	cfg      *config.TopicConf
+	id       string
+	tls      bool
 }
 
 // Direction indicates which of the connectors to connect to
@@ -51,15 +52,15 @@ func New(name string, tls bool, dir Direction, cfg *config.TopicConf, logger *lo
 }
 
 // Connect connects to the configured stream
-func (c *Connection) Connect(ctx context.Context) stan.Conn {
-	c.conn = c.connectSTAN(ctx, c.id, c.name, c.url)
+func (c *Connection) Connect(ctx context.Context, cb func(stan.Conn, error)) stan.Conn {
+	c.conn = c.connectSTAN(ctx, c.id, c.name, c.url, cb)
 
 	return c.conn
 }
 
-func (c *Connection) connectSTAN(ctx context.Context, cid string, name string, urls string) stan.Conn {
-	n := c.connectNATS(ctx, name, urls)
-	if n == nil {
+func (c *Connection) connectSTAN(ctx context.Context, cid string, name string, urls string, cb func(stan.Conn, error)) stan.Conn {
+	c.natsConn = c.connectNATS(ctx, name, urls)
+	if c.natsConn == nil {
 		c.log.Errorf("%s NATS connection could not be established, cannot connect to the Stream", name)
 		return nil
 	}
@@ -71,7 +72,7 @@ func (c *Connection) connectSTAN(ctx context.Context, cid string, name string, u
 	for {
 		try++
 
-		conn, err = stan.Connect(cid, name, stan.NatsConn(n))
+		conn, err = stan.Connect(cid, name, stan.NatsConn(c.natsConn), stan.SetConnectionLostHandler(cb))
 		if err != nil {
 			c.log.Warnf("%s initial connection to the NATS Streaming broker cluster failed: %s", name, err)
 

--- a/connector/connector_test.go
+++ b/connector/connector_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/choria-io/stream-replicator/config"
 	conntest "github.com/choria-io/stream-replicator/connector/test"
+	"github.com/nats-io/go-nats-streaming"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
@@ -69,7 +70,7 @@ var _ = Describe("Connector", func() {
 			defer left.Shutdown()
 
 			c := New("testcon", false, Source, conf, log)
-			con := c.Connect(ctx)
+			con := c.Connect(ctx, func(_ stan.Conn, reason error) {})
 			defer con.Close()
 		})
 	})

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: f7c6a83b9b77ae4741b048388febf0defb7b1e811f52a257b82eb5982eb64392
-updated: 2018-05-30T10:41:02.980026+02:00
+hash: 283e62924a46cfca27e07204e62171df02d36dc739c881eb421b2fc1c706b5d8
+updated: 2018-06-25T11:35:38.17691+03:00
 imports:
 - name: github.com/alecthomas/template
   version: a0175ee3bccc567396460bf5acd36800cb10c49c
@@ -18,7 +18,7 @@ imports:
   version: 2f1ce7a837dcb8da3ec595b1dac9d0632f0f99e8
   repo: https://github.com/boltdb/bolt
 - name: github.com/choria-io/go-choria
-  version: a3b74b8d7769db8ec227d4cf0a75aaebb28ad2fd
+  version: bb84cbd37539a2cdbf890c843ef7c6afc54c6964
   subpackages:
   - build
   - config
@@ -28,7 +28,7 @@ imports:
 - name: github.com/choria-io/go-confkey
   version: 634d2c41860498507b0c7eeb2f8a33b1aa6a809d
 - name: github.com/choria-io/go-security
-  version: 615ff9a3ca0cabc08289e491ef8f57b6a51031a7
+  version: a221c72ee79ab400346d38837d7e8b289857247b
   subpackages:
   - filesec
   - puppetsec
@@ -55,7 +55,7 @@ imports:
   - proto
   - protoc-gen-gogo/descriptor
 - name: github.com/golang/protobuf
-  version: df1d3ca07d2d07bba352d5b73c4313b4e2a6203e
+  version: 9eb2c01ac278a5d89ce4b2be68fe4500955d8179
   subpackages:
   - proto
 - name: github.com/hashicorp/go-immutable-radix
@@ -97,11 +97,11 @@ imports:
   - encoders/builtin
   - util
 - name: github.com/nats-io/go-nats-streaming
-  version: 6e620057a207bd61e992c1c5b6a2de7b6a4cb010
+  version: e15a53f85e4932540600a16b56f6c4f65f58176f
   subpackages:
   - pb
 - name: github.com/nats-io/nats-streaming-server
-  version: 6026da1b7c444bf9f1d1b1d3ed14e435aabf02bc
+  version: 6027b20cd943a9fa598a664e4c8d7514fe684345
   subpackages:
   - logger
   - server
@@ -109,14 +109,14 @@ imports:
   - stores
   - util
 - name: github.com/nats-io/nuid
-  version: 28b996b57a46dd0c2aa3a3dc7fa8780878331d00
+  version: 3e58d42c9cfe5cd9429f1a21ad8f35cd859ba829
 - name: github.com/prometheus/client_golang
   version: 967789050ba94deca04a5e84cce8ad472ce313c1
   subpackages:
   - prometheus
   - prometheus/promhttp
 - name: github.com/prometheus/client_model
-  version: 6f3806018612930941127f2a7c6c453ba2c527d2
+  version: 99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c
   subpackages:
   - go
 - name: github.com/prometheus/common
@@ -132,7 +132,7 @@ imports:
 - name: github.com/sirupsen/logrus
   version: c155da19408a8799da419ed3eeb0cb5db0ad5dbc
 - name: github.com/tidwall/gjson
-  version: 01f00f129617a6fe98941fb920d6c760241b54d2
+  version: f123b340873a0084cb27267eddd8ff615115fbff
 - name: github.com/tidwall/match
   version: 1731857f09b1f38450e2c12409748407822dc6be
 - name: golang.org/x/crypto
@@ -199,7 +199,7 @@ testImports:
   - html/atom
   - html/charset
 - name: golang.org/x/text
-  version: 5c1cf69b5978e5a34c5f9ba09a83e56acc4b7877
+  version: 5cec4b58c438bd98288aeb248bab2c1840713d21
   subpackages:
   - encoding
   - encoding/charmap

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,9 +5,8 @@ import:
 - package: github.com/nats-io/go-nats
   version: ^1
 - package: github.com/nats-io/go-nats-streaming
-  version: '*'
+  version: '>= 0.4.0'
 - package: github.com/prometheus/client_golang
-  version: '>= 0.9.0-pre1'
   subpackages:
   - prometheus
   - prometheus/promhttp


### PR DESCRIPTION
In the past should the STAN connection be interrupted long enough
the whole system would just stop working as on reconnect the server
would not recognise us as valid.

In the go library version 0.4.0 and the server version 0.10.0 a
bidirectional ping was added whereby the client code can get notified on
disconnection.  The problem is one has to entirely recreate all
subscriptions and everything from scratch when this happens.  Quite a
difficult ask for a program that was never developed with that in mind.

Thus to shoe horn this pattern in here we set up a channel where each of
the STAN connections can notify the main manager code who then intiates
a clean shutdown via cancel() and a full fresh restart via Exec() which
would in effect close everything and reopen everything cleanly, it's a
bit brutal as stats will get lost but it gets us somewhere quickly till
we later consider rearchitecting all of this around the new programming
model STAN demands :(